### PR TITLE
Make loading FreeType more robust by searching runtime host's dll search directories

### DIFF
--- a/SharpFont.sln.DotSettings
+++ b/SharpFont.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=libfreetype/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Source/SharpFont/FT.Internal.cs
+++ b/Source/SharpFont/FT.Internal.cs
@@ -23,6 +23,9 @@ SOFTWARE.*/
 #endregion
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 using SharpFont.Cache;
@@ -90,21 +93,46 @@ namespace SharpFont
 			NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), LoadFreetype);
 		}
 
+		private static IEnumerable<string> BinaryCandidates =>
+		[
+			FreetypeDll,
+			"libfreetype.so.6",
+			"libfreetype6.so",
+			"libfreetype.6.dylib"
+		];
+
 		private static IntPtr LoadFreetype(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
 		{
-			if (libraryName != "freetype6") return IntPtr.Zero;
-			bool success = NativeLibrary.TryLoad("freetype6", out IntPtr handle);
-			if (success) return handle;
+			if (libraryName != FreetypeDll) return IntPtr.Zero;
 
-			success = NativeLibrary.TryLoad("libfreetype.so.6", out handle);
-			if (success) return handle;
+			// First, try to load the libraries from the system normally:
+			foreach (string candidate in BinaryCandidates)
+			{
+				bool success = NativeLibrary.TryLoad(candidate, out IntPtr handle);
+				if (success) return handle;
+			}
 
-			success = NativeLibrary.TryLoad("libfreetype6.so", out handle);
-			if (success) return handle;
+			// If that ends up failing let's try and find the library using a routine similar to .NET's normal resolver.
 
-			success = NativeLibrary.TryLoad("libfreetype.6.dylib", out handle);
-			if (success) return handle;
+			// .NET's internal list of directory paths to search for native libraries.
+			// This typically includes the .NET runtime directory and the application's `runtimes/{rid}/native` folder.
+			//
+			// https://learn.microsoft.com/en-us/dotnet/core/dependency-loading/default-probing#host-configured-probing-properties
+			string[] loadPaths = (AppContext.GetData("NATIVE_DLL_SEARCH_DIRECTORIES")?.ToString() ?? "")
+				.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+				.Reverse() // Try to prioritize system entries first before Resonite's bundled dlls
+				.ToArray();
 
+			foreach (string candidate in BinaryCandidates)
+			{
+				foreach (string path in loadPaths)
+				{
+					bool success = NativeLibrary.TryLoad(Path.Combine(path, candidate), out IntPtr handle);
+					if (success) return handle;
+				}
+			}
+
+			// We can't find the library. GG.
 			return IntPtr.Zero;
 		}
 


### PR DESCRIPTION
Some comments on the Resonite issue tracker caught my eye surrounding FreeType: https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/6490#issuecomment-4301383159

The [latest build of Resonite](https://steamdb.info/depot/2519832/history/?changeid=M:4712245474669495749) removed the FreeType binaries from the root of the build. For some people this apparently causes FreeType to be unable to load.

I don't understand why this would happen and I can't reproduce it, but regardless this appears to have uncovered a regression from my changes in #2, I had previously assumed that `NativeLibrary.TryLoad` would search the `runtimes` directory but as it turns out, by looking at documentation and investigating syscalls in Process Monitor, this isn't the case.

So, I've decided to make this system a little more robust. I'm now fetching a list of paths from the .NET Runtime Host (the same ones that would normally be searched by `[DllImport]`) and searching those if the first, previous method fails.

In my testing this appears to happen regardless; freetype6 ends up getting loaded from the correct directory on Windows somehow anyways, but I figure this can't really hurt.